### PR TITLE
Use enableCrop on camera usage (在相機使用情況上使用enablecrop)

### DIFF
--- a/ios/Classes/ImagePickersPlugin.m
+++ b/ios/Classes/ImagePickersPlugin.m
@@ -121,41 +121,21 @@ static NSString *const CHANNEL_NAME = @"flutter/image_pickers";
                 
                 if (image) {
                     
-                    BigImageViewController *big =[[BigImageViewController alloc]init];
-                    big.configuration =configuration ;
-                    big.image =image;
-                    big.doneEditImageBlock = ^(UIImage * imageE) {
-                        NSData *data2=UIImageJPEGRepresentation(imageE , 1.0);
-                        if (data2.length>compressSize) {
-                            //压缩
-                            data2=UIImageJPEGRepresentation(imageE, (float)(compressSize/data2.length));
-                        }
-                        NSLog(@"_____方法__%ld",data2.length);
-                        UIImage *image =[UIImage imageWithData:data2];
-                        //重命名并且保存
-                        NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-                        formatter.dateFormat = @"yyyyMMddHHmmss";
-                        int  x = arc4random() % 10000;
-                        
-                        NSString *name = [NSString stringWithFormat:@"%@01%d",[formatter stringFromDate:[NSDate date]],x];
-                        NSString  *jpgPath = [NSHomeDirectory()     stringByAppendingPathComponent:[NSString stringWithFormat:@"Documents/%@",name]];
-                        
-                        //保存到沙盒
-                        [UIImageJPEGRepresentation(image,1.0) writeToFile:jpgPath atomically:YES];
-                        NSString *aPath3=[NSString stringWithFormat:@"%@/Documents/%@",NSHomeDirectory(),name];
-                        NSDictionary *photoDic =@{
-                            @"thumbPath":[NSString stringWithFormat:@"%@",aPath3],
-                            @"path":[NSString stringWithFormat:@"%@",aPath3],
-                        };
-                        //取出路径
-                        result(@[photoDic]);
-                        return ;
-                        
-                        
-                    };
+                    if (enableCrop) {
                     
-                    [[UIApplication sharedApplication].delegate.window.rootViewController presentViewController:big animated:YES completion:^{
-                    }];
+                        BigImageViewController *big =[[BigImageViewController alloc]init];
+                        big.configuration =configuration ;
+                        big.image =image;
+                        big.doneEditImageBlock = ^(UIImage * imageE) {
+                            [self imagePostProcessing:imageE compressSize:compressSize result:result];
+                            return;
+                        };
+                        
+                        [[UIApplication sharedApplication].delegate.window.rootViewController presentViewController:big animated:YES completion:^{
+                        }];
+                    } else{
+                        [self imagePostProcessing:image compressSize:compressSize result:result];
+                    }
                     
                 }else{
                     
@@ -725,4 +705,32 @@ static NSString *const CHANNEL_NAME = @"flutter/image_pickers";
     NSString *tmpPath = [tmpDirectory stringByAppendingPathComponent:tmpFile];
     return tmpPath;
 }
+
+- (void)imagePostProcessing:(UIImage *)imageE compressSize:(NSInteger)compressSize result:(FlutterResult)result {
+    NSData *data2=UIImageJPEGRepresentation(imageE , 1.0);
+    if (data2.length>compressSize) {
+        //压缩
+        data2=UIImageJPEGRepresentation(imageE, (float)(compressSize/data2.length));
+    }
+    NSLog(@"_____方法__%ld",data2.length);
+    UIImage *image =[UIImage imageWithData:data2];
+    //重命名并且保存
+    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+    formatter.dateFormat = @"yyyyMMddHHmmss";
+    int  x = arc4random() % 10000;
+    
+    NSString *name = [NSString stringWithFormat:@"%@01%d",[formatter stringFromDate:[NSDate date]],x];
+    NSString  *jpgPath = [NSHomeDirectory()     stringByAppendingPathComponent:[NSString stringWithFormat:@"Documents/%@",name]];
+    
+    //保存到沙盒
+    [UIImageJPEGRepresentation(image,1.0) writeToFile:jpgPath atomically:YES];
+    NSString *aPath3=[NSString stringWithFormat:@"%@/Documents/%@",NSHomeDirectory(),name];
+    NSDictionary *photoDic =@{
+        @"thumbPath":[NSString stringWithFormat:@"%@",aPath3],
+        @"path":[NSString stringWithFormat:@"%@",aPath3],
+    };
+    //取出路径
+    result(@[photoDic]);
+}
+
 @end


### PR DESCRIPTION
Currently, when opening the camera directly (Without going through the gallery), the crop operation after image is taken is always enabled, even if enableCrop = false.
This pull request fixes this issue.

當前，當直接打開相機（不經過圖庫）時，即使enableCrop = false，也始終啟用拍攝圖像後的裁剪操作。
此拉取請求解決了此問題。