### PR TITLE
Update image_pickers.dart

### DIFF
--- a/lib/image_pickers.dart
+++ b/lib/image_pickers.dart
@@ -77,7 +77,11 @@ class ImagePickers {
       Media media = Media();
       media.thumbPath = paths[0]["thumbPath"];
       media.path = paths[0]["path"];
-      media.galleryMode = GalleryMode.image;
+      if (mimeType == "video") {
+        media.galleryMode = GalleryMode.video;
+      } else {
+        media.galleryMode = GalleryMode.image;
+      }
       return media;
     }
 


### PR DESCRIPTION
修复openCamera 返回值Media galleryMode类型固定是GalleryMode.image问题