### PR TITLE
移除 android embedding v1 api

### DIFF
--- a/android/src/main/java/com/leeson/image_pickers/ImagePickersPlugin.java
+++ b/android/src/main/java/com/leeson/image_pickers/ImagePickersPlugin.java
@@ -48,28 +48,6 @@ public class ImagePickersPlugin implements FlutterPlugin,MethodChannel.MethodCal
   public ImagePickersPlugin() {
   }
 
-  /**
-   * pre-Flutter-1.12 Android projects.
-   */
-  public static void registerWith(PluginRegistry.Registrar registrar) {
-    ImagePickersPlugin imagePickersPlugin = new ImagePickersPlugin();
-    imagePickersPlugin.setup(registrar,null);
-  }
-
-  private void setup(PluginRegistry.Registrar registrar, ActivityPluginBinding activityBinding){
-    if (registrar != null){
-      activity = registrar.activity();
-      channel = new MethodChannel(registrar.messenger(), "flutter/image_pickers");
-      channel.setMethodCallHandler(this);
-      registrar.addActivityResultListener(listener);
-    }else{
-      activity = activityBinding.getActivity();
-      channel = new MethodChannel(flutterPluginBinding.getFlutterEngine().getDartExecutor(), "flutter/image_pickers");
-      channel.setMethodCallHandler(this);
-      activityBinding.addActivityResultListener(listener);
-    }
-  }
-
   private PluginRegistry.ActivityResultListener listener = new PluginRegistry.ActivityResultListener() {
     @Override
     public boolean onActivityResult(int requestCode, int resultCode, Intent intent) {
@@ -282,6 +260,8 @@ public class ImagePickersPlugin implements FlutterPlugin,MethodChannel.MethodCal
   public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {
     this.flutterPluginBinding = flutterPluginBinding;
 
+    channel = new MethodChannel(flutterPluginBinding.getBinaryMessenger(), "flutter/image_pickers");
+    channel.setMethodCallHandler(this);
   }
 
   @Override
@@ -294,7 +274,8 @@ public class ImagePickersPlugin implements FlutterPlugin,MethodChannel.MethodCal
 
   @Override
   public void onAttachedToActivity(@NonNull ActivityPluginBinding binding) {
-    setup(null,binding);
+    this.activity = binding.getActivity();
+    binding.addActivityResultListener(listener);
   }
 
   @Override
@@ -309,6 +290,6 @@ public class ImagePickersPlugin implements FlutterPlugin,MethodChannel.MethodCal
 
   @Override
   public void onDetachedFromActivity() {
-
+    this.activity = null;
   }
 }


### PR DESCRIPTION
flutter 3.29.0 移除了 v1 Android embedding Java APIs，这个插件中 Android 平台还保留了旧的 API，因此插件不能在 flutter 3.29.0 及以上版本的 Android 平台上使用。ImagePickersPlugin 中移除了旧的 API。